### PR TITLE
replace _filters with params entries

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,25 @@
                     delete params._sortField;
                     delete params._sortDir;
                 }
+
+                if (params._filters)
+                {
+                    var filterValue
+                    for (var filterName in params._filters)
+                    {
+                        filterValue = params._filters[filterName]
+                        if (isNaN(filterValue))
+                        {
+                            filterValue = "like." + filterValue
+                        }
+                        else
+                        {
+                            filterValue = "eq." + filterValue
+                        }
+                        params[filterName] = filterValue;
+                    }
+                    delete params._filters;
+                }
             }
         });
 


### PR DESCRIPTION
Hi, I see that the generated filter request doesn't work. With this branch I replace all filter entries by parameters. I use postgrest version 0.2.12.1 and the ng-admin 0.9
